### PR TITLE
add shallowCompare for react16

### DIFF
--- a/HTML.js
+++ b/HTML.js
@@ -5,6 +5,7 @@ import HTMLElement from './HTMLElement'
 import HTMLTextNode from './HTMLTextNode'
 import HTMLRenderers from './HTMLRenderers'
 import HTMLStyles from './HTMLStyles'
+import shallowCompare from 'react-addons-shallow-compare';
 
 const TEXT_NODES_NAMES = ['p']
 

--- a/HTMLElement.js
+++ b/HTMLElement.js
@@ -3,7 +3,6 @@ import { Text, View } from 'react-native'
 import HTMLStyles from './HTMLStyles'
 import shallowCompare from 'react-addons-shallow-compare';
 
-
 class HTMLElement extends React.PureComponent {
   /* ****************************************************************************/
   // Class

--- a/HTMLElement.js
+++ b/HTMLElement.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Text, View } from 'react-native'
 import HTMLStyles from './HTMLStyles'
+import shallowCompare from 'react-addons-shallow-compare';
+
 
 class HTMLElement extends React.PureComponent {
   /* ****************************************************************************/

--- a/HTMLTextNode.js
+++ b/HTMLTextNode.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Text } from 'react-native'
 import { AllHtmlEntities } from 'html-entities'
+import shallowCompare from 'react-addons-shallow-compare';
 
 const RE = Object.freeze({
   MULT_WHITESPACE: new RegExp(/\s+/g),

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@huston007/react-native-fence-html",
+  "name": "@yuana1/react-native-fence-html",
   "author": "Thomas Beverley",
   "license": "BSD-2-Clause",
   "repository": "https://github.com/Thomas101/react-native-fence-html",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
     "htmlparser2": "^3.9.0",
-    "stream": "0.0.2"
+    "stream": "0.0.2",
+    "react-addons-shallow-compare": "15.5.2"
   },
   "peerDependencies": {
-    "react": ">=0.14.8",
+    "react": ">=15.0.0",
     "react-native": ">=0.24.0"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "html-entities": "^1.2.0",
     "htmlparser2": "^3.9.0",
     "stream": "0.0.2",
-    "react-addons-shallow-compare": "15.5.2"
+    "react-addons-shallow-compare": "^15.5.2"
   },
   "peerDependencies": {
     "react": ">=15.0.0",


### PR DESCRIPTION
  shallowCompare was removed from react 16. 
https://github.com/facebook/react/issues/9207.